### PR TITLE
Allow empty DataFrame creation

### DIFF
--- a/pandas.py
+++ b/pandas.py
@@ -8,7 +8,7 @@ replacement for pandas.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional
 
 
 class Series(list):
@@ -22,10 +22,40 @@ class Series(list):
 class DataFrame:
     """Very small subset of :class:`pandas.DataFrame`."""
 
-    def __init__(self, data: Dict[str, Iterable[Any]]):
+    def __init__(
+        self,
+        data: Optional[Dict[str, Iterable[Any]]] = None,
+        columns: Optional[Iterable[str]] = None,
+        **_: Any,
+    ):
+        """Construct a minimal ``DataFrame``.
+
+        Parameters
+        ----------
+        data:
+            Mapping of column names to iterables. If omitted, an empty
+            ``DataFrame`` is created.
+        columns:
+            Optional explicit column order. When provided, missing columns
+            default to empty lists. Additional keyword arguments are accepted
+            for API compatibility but ignored. This mirrors the behaviour of
+            the real pandas constructor sufficiently for our tests and
+            dashboard code.
+        """
+
+        if data is None:
+            data = {}
+
+        if columns is None:
+            columns = list(data.keys())
+        else:
+            # Ensure all referenced columns exist in ``data``
+            data = {col: list(data.get(col, [])) for col in columns}
+
         self._data = {k: list(v) for k, v in data.items()}
+        self.columns = list(self._data.keys())
         rows = zip(*self._data.values())
-        self._rows: List[Dict[str, Any]] = [dict(zip(self._data.keys(), r)) for r in rows]
+        self._rows: List[Dict[str, Any]] = [dict(zip(self.columns, r)) for r in rows]
 
     class _ILoc:
         def __init__(self, rows: List[Dict[str, Any]]):

--- a/tests/test_pandas_stub.py
+++ b/tests/test_pandas_stub.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+
+def test_empty_dataframe_columns():
+    df = pd.DataFrame(columns=["a", "b"])
+    assert list(df.columns) == ["a", "b"]
+    assert len(df) == 0
+
+
+def test_dataframe_missing_columns_default_empty_lists():
+    df = pd.DataFrame({"a": [1, 2]}, columns=["a", "b"])
+    assert list(df.columns) == ["a", "b"]
+    assert df["a"] == [1, 2]
+    assert df["b"] == []


### PR DESCRIPTION
## Summary
- expand pandas stub `DataFrame` to accept and ignore extra keyword arguments
- verify empty DataFrame creation and default empty columns via new tests

## Testing
- `python3 -m py_compile pandas.py tests/test_pandas_stub.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: 403 Client Error: Can't connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a61ee130388331b957b662266642ed