### PR TITLE
Ensure dashboard uses real pandas

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -6,9 +6,28 @@ Implements placeholders for the production-oriented dashboard blueprint.
 from __future__ import annotations
 
 import datetime as dt
+import importlib
+import sys
+from pathlib import Path
 
-import pandas as pd
 import streamlit as st
+
+
+def _import_real_pandas():
+    """Import the actual pandas package, bypassing the local test stub."""
+    repo_dir = Path(__file__).resolve().parent
+    removed = False
+    if sys.path and Path(sys.path[0]).resolve() == repo_dir:
+        sys.path.pop(0)
+        removed = True
+    try:
+        return importlib.import_module("pandas")
+    finally:
+        if removed:
+            sys.path.insert(0, str(repo_dir))
+
+
+pd = _import_real_pandas()
 
 
 def main() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+import pathlib
+
+# Ensure the local pandas stub is imported before any test runs.
+sys.modules.pop("pandas", None)
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import pandas as pd  # noqa: F401


### PR DESCRIPTION
## Summary
- Load the real pandas package in the Streamlit dashboard to avoid conflicts with the local testing stub
- Guarantee test suite imports the pandas stub by pre-loading it in `conftest`

## Testing
- `pytest`
- `streamlit run dashboard.py --server.headless true --server.port 9999`


------
https://chatgpt.com/codex/tasks/task_e_68a62e640af8833194826132f9a4a841