### PR TITLE
Handle missing timezone gracefully

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, time
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from loguru import logger
 
@@ -16,7 +16,11 @@ class Scheduler:
     """Simple scheduler that decides when to run primary logic."""
 
     def __init__(self, tz: str | ZoneInfo = settings.timezone) -> None:
-        self.tz = ZoneInfo(str(tz))
+        try:
+            self.tz = ZoneInfo(str(tz))
+        except ZoneInfoNotFoundError:
+            logger.warning("Timezone %s not found; falling back to UTC", tz)
+            self.tz = ZoneInfo("UTC")
         self.last_primary: datetime | None = None
 
     def is_primary_time(self, now: datetime) -> bool:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5,6 +5,11 @@ from zoneinfo import ZoneInfo
 from scheduler import Scheduler
 
 
+def test_scheduler_fallback_timezone():
+    sched = Scheduler(tz="Mars/Phobos")
+    assert str(sched.tz) == "UTC"
+
+
 def test_scheduler_runs_on_4h_close_once():
     tz = ZoneInfo("America/New_York")
     sched = Scheduler(tz="America/New_York")

--- a/universe.py
+++ b/universe.py
@@ -24,7 +24,8 @@ def load_universe() -> Sequence[str]:
     if source in {"static", "file"}:
         if not file_path.exists():
             raise FileNotFoundError(file_path)
-        symbols = [line.strip() for line in file_path.read_text().splitlines()[1:] if line.strip()]
+        text = file_path.read_text(encoding="utf-8")
+        symbols = [line.strip() for line in text.splitlines()[1:] if line.strip()]
         logger.debug("Loaded symbols", count=len(symbols))
         return symbols
 


### PR DESCRIPTION
## Summary
- Default scheduler timezone to UTC when specified zone unavailable
- Read universe file with UTF-8 encoding for cross-platform consistency
- Test scheduler fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a63f9686c88331ad5c011d885df862