### PR TITLE
Expand pandas stub with basic DataFrame/Series helpers

### DIFF
--- a/data/market_data.py
+++ b/data/market_data.py
@@ -151,8 +151,22 @@ class IBKRMarketData:
         df = self.get_bars(symbol, "D", 1)
         return float(df["close"].iloc[-1])
 
-    def get_vix(self) -> float:  # pragma: no cover - stub
-        raise NotImplementedError
+    def get_vix(self) -> float:
+        """Return the latest VIX value.
 
-    def get_reference_symbol(self) -> str:  # pragma: no cover - stub
+        The VIX is retrieved as the last closing price of the CBOE Volatility
+        Index.  Only a single day of data is required so a short download
+        window keeps the request lightweight.
+        """
+
+        df = self._download("VIX", "5 D", "1 day")
+        return float(df["close"].iloc[-1])
+
+    def get_reference_symbol(self) -> str:
+        """Symbol used as the market reference for regime detection.
+
+        ``SPY`` – the S&P 500 ETF – acts as a broad market benchmark and is
+        used by the scoring modules when assessing overall market regime.
+        """
+
         return "SPY"

--- a/tests/test_market_data_vix.py
+++ b/tests/test_market_data_vix.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+from data.market_data import IBKRMarketData
+
+
+class DummyIBKRMarketData(IBKRMarketData):
+    """Test double avoiding network calls."""
+
+    def __post_init__(self) -> None:
+        # Skip IB connection
+        pass
+
+    def _download(self, symbol: str, duration: str, bar_size: str) -> pd.DataFrame:
+        assert symbol == "VIX"
+        assert duration == "5 D"
+        assert bar_size == "1 day"
+        return pd.DataFrame({"close": [16.0, 17.5]})
+
+
+def test_get_vix_and_reference_symbol():
+    md = DummyIBKRMarketData()
+    assert md.get_vix() == 17.5
+    assert md.get_reference_symbol() == "SPY"

--- a/tests/test_pandas_stub.py
+++ b/tests/test_pandas_stub.py
@@ -12,3 +12,21 @@ def test_dataframe_missing_columns_default_empty_lists():
     assert list(df.columns) == ["a", "b"]
     assert df["a"] == [1, 2]
     assert df["b"] == []
+
+
+def test_dataframe_rename_tail_and_selection():
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    df = df.rename(columns=str.lower)
+    assert list(df.columns) == ["a", "b"]
+    tail = df.tail(2)
+    assert tail["a"] == [2, 3]
+    subset = df[["a"]]
+    assert list(subset.columns) == ["a"]
+
+
+def test_series_rolling_diff_and_assignment():
+    df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [10, 20, 30, 40]})
+    df["c"] = df["a"].rolling(2).mean()
+    assert df["c"] == [1.0, 1.5, 2.5, 3.5]
+    diff = df["b"].diff()
+    assert diff == [0, 10, 10, 10]


### PR DESCRIPTION
## Summary
- Extend stub `Series` with `rolling().mean()` and `diff`
- Add column selection/assignment plus `rename` and `tail` for stub `DataFrame`
- Cover new functionality with tests
- Implement `get_vix` and `get_reference_symbol` helpers for IBKR market data
- Verify helpers through dedicated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87d8742b88331a623d9224a88b8e3