### PR TITLE
Use Yahoo Finance for market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ cp .env.example .env
 
 Configure the `.env` then launch the Interactive Brokers TWS/Gateway. The default configuration uses SQLite; switch `DB_URL` to a MySQL URL if desired. Set `DEBUG=1` in the `.env` to enable verbose logging during development.
 
+Market data is retrieved from Yahoo Finance so no additional data service
+credentials are required.
+
 ## Universe
 
 By default the bot loads `sp100.csv`. Update this file to refresh the S&P 100 list.

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from loguru import logger
 
 from scheduler import Scheduler
 from universe import load_universe
-from data.market_data import MarketData, IBKRMarketData
+from data.market_data import MarketData, YFinanceMarketData
 from exec.broker import Broker, Order, IBKRBroker
 from exec.orders import build_bracket
 from exec.state import PositionState, next_state
@@ -123,7 +123,7 @@ def main() -> None:  # pragma: no cover - runtime entry
     universe = load_universe()
     logger.info("Loaded universe", count=len(universe))
 
-    market_data = IBKRMarketData()
+    market_data = YFinanceMarketData()
     broker = IBKRBroker()
     bot = TradingBot(market_data, broker)
 

--- a/tests/test_market_data_vix.py
+++ b/tests/test_market_data_vix.py
@@ -1,9 +1,9 @@
 import pandas as pd
 
-from data.market_data import IBKRMarketData
+from data.market_data import YFinanceMarketData
 
 
-class DummyIBKRMarketData(IBKRMarketData):
+class DummyYFinanceMarketData(YFinanceMarketData):
     """Test double avoiding network calls."""
 
     def __post_init__(self) -> None:
@@ -11,13 +11,13 @@ class DummyIBKRMarketData(IBKRMarketData):
         pass
 
     def _download(self, symbol: str, duration: str, bar_size: str) -> pd.DataFrame:
-        assert symbol == "VIX"
+        assert symbol == "^VIX"
         assert duration == "5 D"
         assert bar_size == "1 day"
         return pd.DataFrame({"close": [16.0, 17.5]})
 
 
 def test_get_vix_and_reference_symbol():
-    md = DummyIBKRMarketData()
+    md = DummyYFinanceMarketData()
     assert md.get_vix() == 17.5
     assert md.get_reference_symbol() == "SPY"


### PR DESCRIPTION
## Summary
- add `YFinanceMarketData` provider using the yfinance API
- switch main bot to use Yahoo market data
- document that market data comes from Yahoo Finance
- adjust VIX tests for new provider

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a2a553b88331bedf90823a28c5b5